### PR TITLE
Fix FT2 wrong-period nutc from late decode

### DIFF
--- a/widgets/mainwindow.cpp
+++ b/widgets/mainwindow.cpp
@@ -2725,6 +2725,9 @@ void MainWindow::dataSink(qint64 frames)
     m_dateTime = now.toString ("yyyy-MMM-dd hh:mm");
     if(m_mode!="WSPR") {
       if (m_mode=="FT8" && m_multithreadFT8 && m_ihsym>47) last=now;  // ft8md
+      if (!m_diskData) {
+        m_dateTimeSeqStart = qt_truncate_date_time_to (now, m_TRperiod * 1.e3);
+      }
       decode(); //Start decoder
     }
 
@@ -5846,7 +5849,7 @@ void MainWindow::decode()                                       //decode()
     dec_data.params.nutc=dec_data.params.nutc/100;
   }
   if(dec_data.params.nagain==0 && dec_data.params.newdat==1 && (!m_diskData)) {
-    m_dateTimeSeqStart = qt_truncate_date_time_to (QDateTime::currentDateTimeUtc (), m_TRperiod * 1.e3);
+    // m_dateTimeSeqStart already set by dataSink() before calling decode()
     auto t = m_dateTimeSeqStart.time ();
     dec_data.params.nutc = t.hour () * 100 + t.minute ();
     if (m_TRperiod < 60.)


### PR DESCRIPTION
## Summary

- Fix wrong-period `nutc` timestamp in FT2 decodes caused by a race condition between audio arrival and clock read
- Move `m_dateTimeSeqStart` computation from `decode()` to `dataSink()`, capturing the clock at audio arrival time instead of at decode start time
- Single file changed: `widgets/mainwindow.cpp` (4 lines added, 1 removed)

## Problem

FT2 uses a 3.75-second T/R period with approximately 294 ms margin between the last audio symbol and the period boundary. In the original code, `decode()` reads the wall clock via `QDateTime::currentDateTimeUtc()` to compute `nutc`. The variable delay between audio arriving in `dataSink()` and the clock read in `decode()` can exceed this margin under CPU load, causing `nutc` to be truncated to the **next** period instead of the current one.

The decoded message is then reported with an incorrect timestamp. This probability is significantly higher in FT2 (3.75s period) than in FT8 (15s) or FT4 (7.5s) because the margin is so small.

## Fix

Two edits to `widgets/mainwindow.cpp`:

**Edit A** — In `dataSink()`, set `m_dateTimeSeqStart` from the `now` variable (captured at function entry) immediately before calling `decode()`:

```cpp
if (!m_diskData) {
    m_dateTimeSeqStart = qt_truncate_date_time_to (now, m_TRperiod * 1.e3);
}
decode(); //Start decoder
```

**Edit B** — In `decode()`, remove the redundant clock read:

```cpp
// m_dateTimeSeqStart already set by dataSink() before calling decode()
auto t = m_dateTimeSeqStart.time ();
```

### Why this works

- `dataSink()` captures `now = QDateTime::currentDateTimeUtc()` at function entry, when the audio data arrives — guaranteed to be within the correct T/R period
- `qt_truncate_date_time_to(now, period_ms)` truncates to the period start, giving the correct `m_dateTimeSeqStart`
- `decode()` then uses the pre-computed value instead of re-reading the clock
- The `!m_diskData` guard preserves existing behavior for WAV file playback

## Risk Analysis

| Scenario | Impact |
|----------|--------|
| All modes (not just FT2) | Safe — Edit B's original code only runs under the same `nagain==0 && newdat==1 && !m_diskData` condition, which is the fresh-decode-from-dataSink path |
| Replay / disk data | Unaffected — `!m_diskData` guard preserves WAV playback timestamps |
| Manual re-decode (Decode button) | Unaffected — `nagain != 0`, so the original decode() path does not execute |
| WSPR | Unaffected — excluded by existing `if(m_mode!="WSPR")` guard |
| Multi-threaded FT8 (ft8md) | Unaffected — still calls decode() through the same path |
| JT9-fast (accepted risk) | `fastSink()` can return early before reaching decode() in dataSink(), leaving `m_dateTimeSeqStart` stale — pre-existing condition, JT9-fast essentially unused |

## Known Limitation: Deep-Search Straggler Decodes

Post-patch testing identified 2 occurrences where late decodes still had wrong-period `nutc`. These are a **separate issue** not addressed by this patch:

FT2's Fortran decoder (`ft2_decode.f90`) performs up to 3 subtraction passes with OSD decoding. This deep search can take 4+ seconds — longer than FT2's 3.75s period. When a period's decode cycle completes quickly, `m_decoderBusy` is cleared, and the next period's `dataSink()` triggers a new decode with the correct nutc for that period. The deep search then finds a signal from the previous period in the DT overlap window (±0.5–1.5s) and reports it with the current (triggering) period's nutc.

This is an architectural property of FT2's short period combined with the multi-pass decoder. The nutc accurately reflects which period triggered the decode — the mismatch between the signal's transmit period and the decode's trigger period must be resolved downstream (e.g., by the companion app's existing `ProcessDecodeMsg timing?` detection).

## Test Plan

- [x] Cross-compiled for Windows (GCC 13, matching deployed MSYS2 DLL dependencies)
- [x] Drop-in tested on live FT2 deployment (WM8Q)
- [x] Verified FT2 decodes report correct period timestamps under normal operation
- [x] Confirmed no regressions in FT8 mode
- [x] Confirmed WAV file playback unaffected
- [x] Safety review: 7-point analysis covering all modes and edge cases


🤖 Generated with [Claude Code](https://claude.com/claude-code)